### PR TITLE
依存関係（Apache Commons Lang）を追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,30 +1,33 @@
 plugins {
-	id 'java'
-	id 'war'
-	id 'org.springframework.boot' version '3.3.2'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'war'
+    id 'org.springframework.boot' version '3.3.2'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'raisetech'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    // 便利機能、ユーティリティ
+    implementation 'org.apache.commons:commons-lang3:3.15.0'
+
+    providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }


### PR DESCRIPTION
⚪︎「17_プロジェクトの構成管理_Gradle_Maven」の課題として、「依存関係（Apache Commons Lang）」を「build.gradle」へ追加しました

⚪︎その他の課題は以下のとおり確認しました
（Springframeworkよりapache.commonsの方が機能が多いことを確認）
<img width="676" alt="Springframework" src="https://github.com/user-attachments/assets/16ca281a-bed1-4320-8314-03c82965c3ab">
<img width="674" alt="apache commons" src="https://github.com/user-attachments/assets/7e809dcf-7b45-418e-9925-5f0989dfa3e6">

（MavenとGradleの違いを確認）
<img width="890" alt="Maben" src="https://github.com/user-attachments/assets/9971bf8e-85d2-4e5a-b4e1-66ca37c5d0fa">
<img width="753" alt="Gradle" src="https://github.com/user-attachments/assets/26ec200f-131e-4348-aab8-ea79627da287">
